### PR TITLE
Add compability with latest minetest version

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -35,10 +35,11 @@ minetest.register_chatcommand("sethand", {
 
     -- if not param, return to default hand
     if not param or param == "" then
-      player:get_inventory():set_stack("hand", 1, "")
+      player:get_inventory():set_size("hand", 0)
       return true, "Set to default hand"
     end
 
+    player:get_inventory():set_size("hand", 1)
     player:get_inventory():set_stack("hand", 1, param)
     return true, "Set hand to "..param
   end,


### PR DESCRIPTION
The latest minetest version set hand inventory to 0 by default
Because of it you can't change hand skin on these versions
Here fix that manually setting hand inventory set when setting a new skin 
And clearing it setting to 0